### PR TITLE
Add a Keychain.Status() for checking if Keychain exists

### DIFF
--- a/keychain.go
+++ b/keychain.go
@@ -37,6 +37,8 @@ var (
 	ErrorInteractionNotAllowed = Error(C.errSecInteractionNotAllowed)
 	// ErrorDecode corresponds to errSecDecode result code
 	ErrorDecode = Error(C.errSecDecode)
+	// ErrorNoSuchKeychain corresponds to errSecNoSuchKeychain result code
+	ErrorNoSuchKeychain = Error(C.errSecNoSuchKeychain)
 )
 
 func checkError(errCode C.OSStatus) error {
@@ -56,6 +58,8 @@ func (k Error) Error() string {
 		msg = fmt.Sprintf("Duplicate item (%d)", k)
 	case ErrorParam:
 		msg = fmt.Sprintf("One or more parameters passed to the function were not valid (%d)", k)
+	case ErrorNoSuchKeychain:
+		msg = fmt.Sprintf("No such keychain (%d)", k)
 	case -25243:
 		msg = fmt.Sprintf("No access for item (%d)", k)
 	default:

--- a/macos.go
+++ b/macos.go
@@ -175,6 +175,19 @@ func NewWithPath(path string) Keychain {
 	}
 }
 
+// Status returns the status of the keychain
+func (kc Keychain) Status() error {
+	// returns no error even if it doesn't exist
+	kref, err := openKeychainRef(kc.path)
+	if err != nil {
+		return err
+	}
+	defer C.CFRelease(C.CFTypeRef(kref))
+
+	var status C.SecKeychainStatus
+	return checkError(C.SecKeychainGetStatus(kref, &status))
+}
+
 // The returned SecKeychainRef, if non-nil, must be released via CFRelease.
 func openKeychainRef(path string) (C.SecKeychainRef, error) {
 	pathName := C.CString(path)

--- a/macos_test.go
+++ b/macos_test.go
@@ -3,9 +3,11 @@
 package keychain
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestAccess(t *testing.T) {
@@ -200,5 +202,23 @@ func TestNewWithPath(t *testing.T) {
 	}
 	if string(results[0].Data) != "toomanysecrets2" {
 		t.Fatalf("Invalid password: %s", results[0].Data)
+	}
+}
+
+func TestStatus(t *testing.T) {
+	path := tempPath(t)
+	defer func() { _ = os.Remove(path) }()
+	k, newErr := NewKeychain(path, "testkeychainpassword")
+	if newErr != nil {
+		t.Fatal(newErr)
+	}
+
+	if err := k.Status(); err != nil {
+		t.Fatal(err)
+	}
+
+	nonexistent := NewWithPath(fmt.Sprintf("this_shouldnt_exist_%d", time.Now()))
+	if err := nonexistent.Status(); err != ErrorNoSuchKeychain {
+		t.Fatalf("Expected %v, get %v", ErrorNoSuchKeychain, err)
 	}
 }


### PR DESCRIPTION
The only reliable way I've found of detecting if a keychain exists or not seems to be [SecKeychainGetStatus](https://developer.apple.com/documentation/security/1399085-seckeychaingetstatus?language=objc). This exposes that method so that you can do:

```go
k := NewWithPath("my.keychain")
if err := k.Status(); err != ErrorNoSuchKeychain {
    log.Fatalf("Keychain doesn't exist yet")
}
```