### PR TITLE
Allow opt-out of trust application when setting access

### DIFF
--- a/macos.go
+++ b/macos.go
@@ -89,12 +89,6 @@ func createTrustedApplication(trustedApplication string) (C.CFTypeRef, error) {
 	return C.CFTypeRef(trustedApplicationRef), nil
 }
 
-// NoApplicationsTrusted is a helper value for an Access level where no applications
-// are trusted and the user will have to explicitly approve all
-var NoApplicationsTrusted = &Access{
-	SelfUntrusted: true,
-}
-
 // Access defines whats applications can use the keychain item
 type Access struct {
 	SelfUntrusted       bool

--- a/macos.go
+++ b/macos.go
@@ -35,14 +35,11 @@ var (
 
 // createAccess creates a SecAccessRef as CFTypeRef.
 // The returned SecAccessRef, if non-nil, must be released via CFRelease.
-func createAccess(label string, trustedApplications []string) (C.CFTypeRef, error) {
-	if len(trustedApplications) == 0 {
-		return nil, nil
+func createAccess(label string, trustedApplications []string, trustSelf bool) (C.CFTypeRef, error) {
+	if trustSelf {
+		// A NULL application means ourselves, the current application
+		trustedApplications = append([]string{""}, trustedApplications...)
 	}
-
-	// Always prepend with empty string which signifies that we
-	// include a NULL application, which means ourselves.
-	trustedApplications = append([]string{""}, trustedApplications...)
 
 	var err error
 	var labelRef C.CFStringRef
@@ -92,8 +89,15 @@ func createTrustedApplication(trustedApplication string) (C.CFTypeRef, error) {
 	return C.CFTypeRef(trustedApplicationRef), nil
 }
 
+// NoApplicationsTrusted is a helper value for an Access level where no applications
+// are trusted and the user will have to explicitly approve all
+var NoApplicationsTrusted = &Access{
+	SelfUntrusted: true,
+}
+
 // Access defines whats applications can use the keychain item
 type Access struct {
+	SelfUntrusted       bool
 	Label               string
 	TrustedApplications []string
 }
@@ -101,7 +105,7 @@ type Access struct {
 // Convert converts Access to CFTypeRef.
 // The returned CFTypeRef, if non-nil, must be released via CFRelease.
 func (a Access) Convert() (C.CFTypeRef, error) {
-	return createAccess(a.Label, a.TrustedApplications)
+	return createAccess(a.Label, a.TrustedApplications, !a.SelfUntrusted)
 }
 
 // SetAccess sets Access on Item

--- a/macos_test.go
+++ b/macos_test.go
@@ -22,6 +22,19 @@ func TestAccess(t *testing.T) {
 	}
 }
 
+func TestAccessWithoutTrust(t *testing.T) {
+	var err error
+
+	item := NewGenericPassword("TestAccess", "test2", "A label", []byte("toomanysecrets2"), "")
+	defer func() { _ = DeleteItem(item) }()
+
+	item.SetAccess(NoApplicationsTrusted)
+	err = AddItem(item)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestUpdateItem(t *testing.T) {
 	var err error
 


### PR DESCRIPTION
For security sensitive applications I'd like to be able to opt out of the current default of adding access for the current app:

https://github.com/keybase/go-keychain/blob/69c518e5bfff89ad62db81a185634d3aeac3c453/macos.go#L45

This adds a `SelfUntrusted` bool to the `Access` object. Awkward name, but it makes it backwards compatible. There is also a `NoApplicationsTrusted` value that can be used with `SetAccess`. 