### PR TITLE
Allow no trusted applications when setting access

### DIFF
--- a/macos.go
+++ b/macos.go
@@ -36,14 +36,6 @@ var (
 // createAccess creates a SecAccessRef as CFTypeRef.
 // The returned SecAccessRef, if non-nil, must be released via CFRelease.
 func createAccess(label string, trustedApplications []string) (C.CFTypeRef, error) {
-	if len(trustedApplications) == 0 {
-		return nil, nil
-	}
-
-	// Always prepend with empty string which signifies that we
-	// include a NULL application, which means ourselves.
-	trustedApplications = append([]string{""}, trustedApplications...)
-
 	var err error
 	var labelRef C.CFStringRef
 	if labelRef, err = StringToCFString(label); err != nil {
@@ -51,19 +43,29 @@ func createAccess(label string, trustedApplications []string) (C.CFTypeRef, erro
 	}
 	defer C.CFRelease(C.CFTypeRef(labelRef))
 
-	var trustedApplicationsRefs []C.CFTypeRef
-	for _, trustedApplication := range trustedApplications {
-		trustedApplicationRef, createErr := createTrustedApplication(trustedApplication)
-		if createErr != nil {
-			return nil, createErr
+	var trustedApplicationsArray C.CFArrayRef
+	if trustedApplications != nil {
+		if len(trustedApplications) > 0 {
+			// Always prepend with empty string which signifies that we
+			// include a NULL application, which means ourselves.
+			trustedApplications = append([]string{""}, trustedApplications...)
 		}
-		defer C.CFRelease(C.CFTypeRef(trustedApplicationRef))
-		trustedApplicationsRefs = append(trustedApplicationsRefs, trustedApplicationRef)
+
+		var trustedApplicationsRefs []C.CFTypeRef
+		for _, trustedApplication := range trustedApplications {
+			trustedApplicationRef, createErr := createTrustedApplication(trustedApplication)
+			if createErr != nil {
+				return nil, createErr
+			}
+			defer C.CFRelease(C.CFTypeRef(trustedApplicationRef))
+			trustedApplicationsRefs = append(trustedApplicationsRefs, trustedApplicationRef)
+		}
+
+		trustedApplicationsArray = ArrayToCFArray(trustedApplicationsRefs)
+		defer C.CFRelease(C.CFTypeRef(trustedApplicationsArray))
 	}
 
 	var access C.SecAccessRef
-	trustedApplicationsArray := ArrayToCFArray(trustedApplicationsRefs)
-	defer C.CFRelease(C.CFTypeRef(trustedApplicationsArray))
 	errCode := C.SecAccessCreate(labelRef, trustedApplicationsArray, &access)
 	err = checkError(errCode)
 	if err != nil {

--- a/macos_test.go
+++ b/macos_test.go
@@ -13,11 +13,50 @@ import (
 func TestAccess(t *testing.T) {
 	var err error
 
-	item := NewGenericPassword("TestAccess", "test2", "A label", []byte("toomanysecrets2"), "")
+	service, account, label, accessGroup, password := "TestAccess", "test2", "A label", "", "toomanysecrets2"
+	item := NewGenericPassword(service, account, label, []byte(password), accessGroup)
 	defer func() { _ = DeleteItem(item) }()
 
 	trustedApplications := []string{"/Applications/Mail.app"}
 	item.SetAccess(&Access{Label: "Mail", TrustedApplications: trustedApplications})
+	err = AddItem(item)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = GetGenericPassword(service, account, label, accessGroup)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAccessWithImpliedSelf(t *testing.T) {
+	var err error
+
+	service, account, label, accessGroup, password := "TestAccess", "test2", "A label", "", "toomanysecrets2"
+	item := NewGenericPassword(service, account, label, []byte(password), accessGroup)
+	defer func() { _ = DeleteItem(item) }()
+
+	item.SetAccess(&Access{Label: "Self", TrustedApplications: nil})
+	err = AddItem(item)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = GetGenericPassword(service, account, label, accessGroup)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAccessWithoutTrust(t *testing.T) {
+	var err error
+
+	item := NewGenericPassword("TestAccess", "test2", "A label", []byte("toomanysecrets2"), "")
+	defer func() { _ = DeleteItem(item) }()
+
+	trustedApplications := []string{}
+	item.SetAccess(&Access{Label: "No Trust", TrustedApplications: trustedApplications})
 	err = AddItem(item)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The Access field TrustedApplications can now be set to nil or an empty
slice, better matching the SecAccessCreate API.

When nil, access control list is automatically set to the application
creating the item. When an empty slice no applications are trusted for
the item created.

Due to the fact that (Access).Convert() would have returned nil if
len(TrustedApplications) == 0 causing a SIGTRAP, this is a backward-
compatible change to the API. While this doesn't cover all cases (e.g.
providing a list of trusted applications, but while not trusting the
calling application), I believe this will cover many common cases.