### PR TITLE
Update for cgo changes in go 1.10

### DIFF
--- a/corefoundation.go
+++ b/corefoundation.go
@@ -1,4 +1,4 @@
-// +build darwin
+// +build darwin ios
 
 package keychain
 
@@ -66,15 +66,17 @@ func MapToCFDictionary(m map[C.CFTypeRef]C.CFTypeRef) (C.CFDictionaryRef, error)
 }
 
 // CFDictionaryToMap converts CFDictionaryRef to a map.
-func CFDictionaryToMap(cfDict C.CFDictionaryRef) (m map[C.CFTypeRef]C.CFTypeRef) {
+func CFDictionaryToMap(cfDict C.CFDictionaryRef) (m map[C.CFTypeRef]uintptr) {
 	count := C.CFDictionaryGetCount(cfDict)
 	if count > 0 {
 		keys := make([]C.CFTypeRef, count)
 		values := make([]C.CFTypeRef, count)
 		C.CFDictionaryGetKeysAndValues(cfDict, (*unsafe.Pointer)(unsafe.Pointer(&keys[0])), (*unsafe.Pointer)(unsafe.Pointer(&values[0])))
-		m = make(map[C.CFTypeRef]C.CFTypeRef, count)
+		m = make(map[C.CFTypeRef]uintptr, count)
 		for i := C.CFIndex(0); i < count; i++ {
-			m[keys[i]] = values[i]
+			k := keys[i]
+			v := values[i]
+			m[k] = uintptr(v)
 		}
 	}
 	return
@@ -256,7 +258,7 @@ func ConvertCFDictionary(d C.CFDictionaryRef) (map[interface{}]interface{}, erro
 		if err != nil {
 			return nil, err
 		}
-		gv, err := Convert(v)
+		gv, err := Convert(C.CFTypeRef(v))
 		if err != nil {
 			return nil, err
 		}

--- a/corefoundation.go
+++ b/corefoundation.go
@@ -26,15 +26,15 @@ func Release(ref C.CFTypeRef) {
 // Release(ref).
 func BytesToCFData(b []byte) (C.CFDataRef, error) {
 	if uint64(len(b)) > math.MaxUint32 {
-		return nil, errors.New("Data is too large")
+		return 0, errors.New("Data is too large")
 	}
 	var p *C.UInt8
 	if len(b) > 0 {
 		p = (*C.UInt8)(&b[0])
 	}
 	cfData := C.CFDataCreate(nil, p, C.CFIndex(len(b)))
-	if cfData == nil {
-		return nil, fmt.Errorf("CFDataCreate failed")
+	if cfData == 0 {
+		return 0, fmt.Errorf("CFDataCreate failed")
 	}
 	return cfData, nil
 }
@@ -59,8 +59,8 @@ func MapToCFDictionary(m map[C.CFTypeRef]C.CFTypeRef) (C.CFDictionaryRef, error)
 		valuesPointer = &values[0]
 	}
 	cfDict := C.CFDictionaryCreate(nil, keysPointer, valuesPointer, C.CFIndex(numValues), &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
-	if cfDict == nil {
-		return nil, fmt.Errorf("CFDictionaryCreate failed")
+	if cfDict == 0 {
+		return 0, fmt.Errorf("CFDictionaryCreate failed")
 	}
 	return cfDict, nil
 }
@@ -71,7 +71,7 @@ func CFDictionaryToMap(cfDict C.CFDictionaryRef) (m map[C.CFTypeRef]C.CFTypeRef)
 	if count > 0 {
 		keys := make([]C.CFTypeRef, count)
 		values := make([]C.CFTypeRef, count)
-		C.CFDictionaryGetKeysAndValues(cfDict, (*unsafe.Pointer)(&keys[0]), (*unsafe.Pointer)(&values[0]))
+		C.CFDictionaryGetKeysAndValues(cfDict, (*unsafe.Pointer)(unsafe.Pointer(&keys[0])), (*unsafe.Pointer)(unsafe.Pointer(&values[0])))
 		m = make(map[C.CFTypeRef]C.CFTypeRef, count)
 		for i := C.CFIndex(0); i < count; i++ {
 			m[keys[i]] = values[i]
@@ -84,10 +84,10 @@ func CFDictionaryToMap(cfDict C.CFDictionaryRef) (m map[C.CFTypeRef]C.CFTypeRef)
 // Release(ref).
 func StringToCFString(s string) (C.CFStringRef, error) {
 	if !utf8.ValidString(s) {
-		return nil, errors.New("Invalid UTF-8 string")
+		return 0, errors.New("Invalid UTF-8 string")
 	}
 	if uint64(len(s)) > math.MaxUint32 {
-		return nil, errors.New("String is too large")
+		return 0, errors.New("String is too large")
 	}
 
 	bytes := []byte(s)
@@ -138,7 +138,7 @@ func CFArrayToArray(cfArray C.CFArrayRef) (a []C.CFTypeRef) {
 	count := C.CFArrayGetCount(cfArray)
 	if count > 0 {
 		a = make([]C.CFTypeRef, count)
-		C.CFArrayGetValues(cfArray, C.CFRange{0, count}, (*unsafe.Pointer)(&a[0]))
+		C.CFArrayGetValues(cfArray, C.CFRange{0, count}, (*unsafe.Pointer)(unsafe.Pointer(&a[0])))
 	}
 	return
 }
@@ -156,7 +156,7 @@ func ConvertMapToCFDictionary(attr map[string]interface{}) (C.CFDictionaryRef, e
 		var valueRef C.CFTypeRef
 		switch val := i.(type) {
 		default:
-			return nil, fmt.Errorf("Unsupported value type: %v", reflect.TypeOf(i))
+			return 0, fmt.Errorf("Unsupported value type: %v", reflect.TypeOf(i))
 		case C.CFTypeRef:
 			valueRef = val
 		case bool:
@@ -168,28 +168,28 @@ func ConvertMapToCFDictionary(attr map[string]interface{}) (C.CFDictionaryRef, e
 		case []byte:
 			bytesRef, err := BytesToCFData(val)
 			if err != nil {
-				return nil, err
+				return 0, err
 			}
 			valueRef = C.CFTypeRef(bytesRef)
 			defer Release(valueRef)
 		case string:
 			stringRef, err := StringToCFString(val)
 			if err != nil {
-				return nil, err
+				return 0, err
 			}
 			valueRef = C.CFTypeRef(stringRef)
 			defer Release(valueRef)
 		case Convertable:
 			convertedRef, err := val.Convert()
 			if err != nil {
-				return nil, err
+				return 0, err
 			}
 			valueRef = C.CFTypeRef(convertedRef)
 			defer Release(valueRef)
 		}
 		keyRef, err := StringToCFString(key)
 		if err != nil {
-			return nil, err
+			return 0, err
 		}
 		m[C.CFTypeRef(keyRef)] = valueRef
 		defer Release(C.CFTypeRef(keyRef))
@@ -197,7 +197,7 @@ func ConvertMapToCFDictionary(attr map[string]interface{}) (C.CFDictionaryRef, e
 
 	cfDict, err := MapToCFDictionary(m)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	return cfDict, nil
 }

--- a/ios/bind.framework/Versions/A/Headers/Bind.objc.h
+++ b/ios/bind.framework/Versions/A/Headers/Bind.objc.h
@@ -17,14 +17,28 @@
 - (void)fail:(NSString*)s;
 @end
 
+/**
+ * AddGenericPassword adds generic password
+ */
 FOUNDATION_EXPORT BOOL BindAddGenericPassword(NSString* service, NSString* account, NSString* label, NSString* password, NSString* accessGroup, NSError** error);
 
+/**
+ * DeleteGenericPassword deletes generic password
+ */
 FOUNDATION_EXPORT BOOL BindDeleteGenericPassword(NSString* service, NSString* account, NSString* accessGroup, NSError** error);
 
+/**
+ * GenericPasswordTest runs test code for generic password keychain item.
+This is here so we can export using gomobile bind and run this method on iOS simulator and device.
+Access groups aren't supported in iOS simulator.
+ */
 FOUNDATION_EXPORT void BindGenericPasswordTest(id<BindTest> t, NSString* service, NSString* accessGroup);
 
 @class BindTest;
 
+/**
+ * Test is a bind interface for the test
+ */
 @interface BindTest : NSObject <goSeqRefInterface, BindTest> {
 }
 @property(strong, readonly) id _ref;

--- a/keychain.go
+++ b/keychain.go
@@ -335,18 +335,18 @@ type QueryResult struct {
 func QueryItemRef(item Item) (C.CFTypeRef, error) {
 	cfDict, err := ConvertMapToCFDictionary(item.attr)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	defer Release(C.CFTypeRef(cfDict))
 
 	var resultsRef C.CFTypeRef
 	errCode := C.SecItemCopyMatching(cfDict, &resultsRef)
 	if Error(errCode) == ErrorItemNotFound {
-		return nil, nil
+		return 0, nil
 	}
 	err = checkError(errCode)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	return resultsRef, nil
 }
@@ -357,7 +357,7 @@ func QueryItem(item Item) ([]QueryResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	if resultsRef == nil {
+	if resultsRef == 0 {
 		return nil, nil
 	}
 	defer Release(resultsRef)

--- a/macos.go
+++ b/macos.go
@@ -39,7 +39,7 @@ func createAccess(label string, trustedApplications []string) (C.CFTypeRef, erro
 	var err error
 	var labelRef C.CFStringRef
 	if labelRef, err = StringToCFString(label); err != nil {
-		return nil, err
+		return 0, err
 	}
 	defer C.CFRelease(C.CFTypeRef(labelRef))
 
@@ -55,7 +55,7 @@ func createAccess(label string, trustedApplications []string) (C.CFTypeRef, erro
 		for _, trustedApplication := range trustedApplications {
 			trustedApplicationRef, createErr := createTrustedApplication(trustedApplication)
 			if createErr != nil {
-				return nil, createErr
+				return 0, createErr
 			}
 			defer C.CFRelease(C.CFTypeRef(trustedApplicationRef))
 			trustedApplicationsRefs = append(trustedApplicationsRefs, trustedApplicationRef)
@@ -69,7 +69,7 @@ func createAccess(label string, trustedApplications []string) (C.CFTypeRef, erro
 	errCode := C.SecAccessCreate(labelRef, trustedApplicationsArray, &access)
 	err = checkError(errCode)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 
 	return C.CFTypeRef(access), nil
@@ -88,7 +88,7 @@ func createTrustedApplication(trustedApplication string) (C.CFTypeRef, error) {
 	errCode := C.SecTrustedApplicationCreateFromPath(trustedApplicationCStr, &trustedApplicationRef)
 	err := checkError(errCode)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 
 	return C.CFTypeRef(trustedApplicationRef), nil
@@ -151,11 +151,11 @@ func newKeychain(path, password string, promptUser bool) (Keychain, error) {
 	var kref C.SecKeychainRef
 
 	if promptUser {
-		errCode = C.SecKeychainCreate(pathRef, C.UInt32(0), nil, C.Boolean(1), nil, &kref)
+		errCode = C.SecKeychainCreate(pathRef, C.UInt32(0), nil, C.Boolean(1), 0, &kref)
 	} else {
 		passwordRef := C.CString(password)
 		defer C.free(unsafe.Pointer(passwordRef))
-		errCode = C.SecKeychainCreate(pathRef, C.UInt32(len(password)), unsafe.Pointer(passwordRef), C.Boolean(0), nil, &kref)
+		errCode = C.SecKeychainCreate(pathRef, C.UInt32(len(password)), unsafe.Pointer(passwordRef), C.Boolean(0), 0, &kref)
 	}
 
 	if err := checkError(errCode); err != nil {
@@ -197,7 +197,7 @@ func openKeychainRef(path string) (C.SecKeychainRef, error) {
 
 	var kref C.SecKeychainRef
 	if err := checkError(C.SecKeychainOpen(pathName, &kref)); err != nil {
-		return nil, err
+		return 0, err
 	}
 
 	return kref, nil
@@ -252,11 +252,11 @@ func (ka keychainArray) Convert() (C.CFTypeRef, error) {
 		if refs[idx], err = kc.Convert(); err != nil {
 			// If we error trying to convert lets release any we converted before
 			for _, ref := range refs {
-				if ref != nil {
+				if ref != 0 {
 					Release(ref)
 				}
 			}
-			return nil, err
+			return 0, err
 		}
 	}
 

--- a/macos_test.go
+++ b/macos_test.go
@@ -121,7 +121,7 @@ func TestGenericPasswordRef(t *testing.T) {
 	ref, err := QueryItemRef(query)
 	if err != nil {
 		t.Fatal(err)
-	} else if ref == nil {
+	} else if ref == 0 {
 		t.Fatal("Missing result")
 	} else {
 		err = DeleteItemRef(ref)
@@ -256,7 +256,7 @@ func TestStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	nonexistent := NewWithPath(fmt.Sprintf("this_shouldnt_exist_%d", time.Now()))
+	nonexistent := NewWithPath(fmt.Sprintf("this_shouldnt_exist_%s", time.Now().String()))
 	if err := nonexistent.Status(); err != ErrorNoSuchKeychain {
 		t.Fatalf("Expected %v, get %v", ErrorNoSuchKeychain, err)
 	}


### PR DESCRIPTION
https://tip.golang.org/doc/go1.10#cgo

> Cgo now translates some C types that would normally map to a pointer type in Go, to a uintptr instead. These types include the CFTypeRef hierarchy in Darwin's CoreFoundation framework


> Because of this change, values of the affected types need to be zero-initialized with the constant 0 instead of the constant nil. Go 1.10 provides gofix modules to help with that rewrite:

```sh
go tool fix -r cftype $GOPATH/src/github.com/keybase/go-keychain
```

Ran go tool fix on this package. MacOS and iOS tests run successfully.