### PR TITLE
Fix C code to work with Go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: go
+go_import_path: github.com/keybase/go-keychain
+
+os: osx
+sudo: false
+
+script:
+  - go test ./...
+
+go:
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - master
+
+cache:
+  directories:
+    - $GOPATH/pkg

--- a/corefoundation_1.11.go
+++ b/corefoundation_1.11.go
@@ -1,6 +1,5 @@
 // +build darwin ios
-// +build go1.10
-// +build !go1.11
+// +build go1.11
 
 package keychain
 
@@ -53,7 +52,7 @@ func BytesToCFData(b []byte) (C.CFDataRef, error) {
 	if len(b) > 0 {
 		p = (*C.UInt8)(&b[0])
 	}
-	cfData := C.CFDataCreate(nil, p, C.CFIndex(len(b)))
+	cfData := C.CFDataCreate(0, p, C.CFIndex(len(b)))
 	if cfData == 0 {
 		return 0, fmt.Errorf("CFDataCreate failed")
 	}
@@ -79,7 +78,7 @@ func MapToCFDictionary(m map[C.CFTypeRef]C.CFTypeRef) (C.CFDictionaryRef, error)
 		keysPointer = &keys[0]
 		valuesPointer = &values[0]
 	}
-	cfDict := C.CFDictionaryCreateSafe2(nil, keysPointer, valuesPointer, C.CFIndex(numValues), &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
+	cfDict := C.CFDictionaryCreateSafe2(0, keysPointer, valuesPointer, C.CFIndex(numValues), &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
 	if cfDict == 0 {
 		return 0, fmt.Errorf("CFDictionaryCreate failed")
 	}
@@ -116,7 +115,7 @@ func StringToCFString(s string) (C.CFStringRef, error) {
 	if len(bytes) > 0 {
 		p = (*C.UInt8)(&bytes[0])
 	}
-	return C.CFStringCreateWithBytes(nil, p, C.CFIndex(len(s)), C.kCFStringEncodingUTF8, C.false), nil
+	return C.CFStringCreateWithBytes(0, p, C.CFIndex(len(s)), C.kCFStringEncodingUTF8, C.false), nil
 }
 
 // CFStringToString converts a CFStringRef to a string.
@@ -151,7 +150,7 @@ func ArrayToCFArray(a []C.CFTypeRef) C.CFArrayRef {
 	if numValues > 0 {
 		valuesPointer = &values[0]
 	}
-	return C.CFArrayCreateSafe2(nil, valuesPointer, C.CFIndex(numValues), &C.kCFTypeArrayCallBacks)
+	return C.CFArrayCreateSafe2(0, valuesPointer, C.CFIndex(numValues), &C.kCFTypeArrayCallBacks)
 }
 
 // CFArrayToArray converts a CFArrayRef to an array of CFTypes.


### PR DESCRIPTION
Go commit https://github.com/golang/go/commit/94076feef changed the way that
some C types are handled. Per Keith Randall, "places where they weren't being
converted caused mismatches between source files in the same package."

He suggested on golang/go#26721 that we should change the `nil` types to `0`.
Doing so makes the code compile on tip.

Further, add a `.travis.yml` so we can automatically
compile + test on master. A sample build can be found here:
https://travis-ci.org/kevinburkeomg/go-keychain/jobs/410508844