### PR TITLE
Fix C code to work with Go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: go
+
+os: osx
+
+script:
+  - go vet ./...
+  - golint ./...
+  - go test ./...
+
+go:
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - master
+
+cache:
+  directories:
+    - $GOPATH/pkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,3 @@ go:
   - 1.9.x
   - 1.10.x
   - master
-
-cache:
-  directories:
-    - $GOPATH/pkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: go
 
 os: osx
 
+before_install:
+  - go get golang.org/x/lint/golint
+
 script:
   - go vet ./...
   - golint ./...

--- a/corefoundation_1.10.go
+++ b/corefoundation_1.10.go
@@ -52,7 +52,7 @@ func BytesToCFData(b []byte) (C.CFDataRef, error) {
 	if len(b) > 0 {
 		p = (*C.UInt8)(&b[0])
 	}
-	cfData := C.CFDataCreate(nil, p, C.CFIndex(len(b)))
+	cfData := C.CFDataCreate(C.kCFAllocatorDefault, p, C.CFIndex(len(b)))
 	if cfData == 0 {
 		return 0, fmt.Errorf("CFDataCreate failed")
 	}
@@ -78,7 +78,7 @@ func MapToCFDictionary(m map[C.CFTypeRef]C.CFTypeRef) (C.CFDictionaryRef, error)
 		keysPointer = &keys[0]
 		valuesPointer = &values[0]
 	}
-	cfDict := C.CFDictionaryCreateSafe2(nil, keysPointer, valuesPointer, C.CFIndex(numValues), &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
+	cfDict := C.CFDictionaryCreateSafe2(C.kCFAllocatorDefault, keysPointer, valuesPointer, C.CFIndex(numValues), &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
 	if cfDict == 0 {
 		return 0, fmt.Errorf("CFDictionaryCreate failed")
 	}
@@ -115,7 +115,7 @@ func StringToCFString(s string) (C.CFStringRef, error) {
 	if len(bytes) > 0 {
 		p = (*C.UInt8)(&bytes[0])
 	}
-	return C.CFStringCreateWithBytes(nil, p, C.CFIndex(len(s)), C.kCFStringEncodingUTF8, C.false), nil
+	return C.CFStringCreateWithBytes(C.kCFAllocatorDefault, p, C.CFIndex(len(s)), C.kCFStringEncodingUTF8, C.false), nil
 }
 
 // CFStringToString converts a CFStringRef to a string.
@@ -150,7 +150,7 @@ func ArrayToCFArray(a []C.CFTypeRef) C.CFArrayRef {
 	if numValues > 0 {
 		valuesPointer = &values[0]
 	}
-	return C.CFArrayCreateSafe2(nil, valuesPointer, C.CFIndex(numValues), &C.kCFTypeArrayCallBacks)
+	return C.CFArrayCreateSafe2(C.kCFAllocatorDefault, valuesPointer, C.CFIndex(numValues), &C.kCFTypeArrayCallBacks)
 }
 
 // CFArrayToArray converts a CFArrayRef to an array of CFTypes.


### PR DESCRIPTION
https://github.com/golang/go/commit/94076feef made C type checking stricter.
This caused problems where we were passing in nil for CFAllocatorRef, as Go 1.11
will require those to be 0 instead.

Use the typed constant kCFAllocatorDefault to avoid this problem.

Also add a .travis.yml config and test on various Go versions, including master.

This PR is based on code from https://github.com/keybase/go-keychain/pull/30 by
@kevinburkeomg.