### PR TITLE
Ignore deprecations to allow compilations on macOS Catalina

### DIFF
--- a/macos.go
+++ b/macos.go
@@ -4,6 +4,7 @@ package keychain
 
 /*
 #cgo LDFLAGS: -framework CoreFoundation -framework Security
+#cgo CFLAGS: -w
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <Security/Security.h>


### PR DESCRIPTION
Work around the deprecated `SecTrustedApplicationCreateFromPath` by ignoring compiler warnings

Fixes #54 
