### PR TITLE
Add note of keychain.GetGenericPassword

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ if err == keychain.ErrorDuplicateItem {
   // Duplicate
 }
 
+password, err := keychain.GetGenericPassword("MyService", "gabriel", "A label", "A123456789.group.com.mycorp")
+
 accounts, err := keychain.GetGenericPasswordAccounts("MyService")
 // Should have 1 account == "gabriel"
 


### PR DESCRIPTION
The "convenience methods for generic passwords" section of the README forgets to mention `GetGenericPassword` which is seemingly the most important of them all.