### PR TITLE
Use upstream dbus library to fix "authentication failed" errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/keybase/go-keychain
 go 1.17
 
 require (
-	github.com/keybase/go.dbus v0.0.0-20200324223359-a94be52c0b03
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59
@@ -11,6 +10,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/keybase/go.dbus v0.0.0-20200324223359-a94be52c0b03 h1:k9rCqucCsPpBKDh9gDwk3U46TcNd7jpKahed9JGICGY=
-github.com/keybase/go.dbus v0.0.0-20200324223359-a94be52c0b03/go.mod h1:a8clEhrrGV/d76/f9r2I41BwANMihfZYV9C223vaxqE=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/secretservice/secretservice.go
+++ b/secretservice/secretservice.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"time"
 
-	dbus "github.com/keybase/go.dbus"
+	"github.com/godbus/dbus/v5"
 	errors "github.com/pkg/errors"
 )
 
@@ -82,12 +82,12 @@ func (s *SecretService) SetSessionOpenTimeout(d time.Duration) {
 }
 
 // ServiceObj
-func (s *SecretService) ServiceObj() *dbus.Object {
+func (s *SecretService) ServiceObj() dbus.BusObject {
 	return s.conn.Object(SecretServiceInterface, SecretServiceObjectPath)
 }
 
 // Obj
-func (s *SecretService) Obj(path dbus.ObjectPath) *dbus.Object {
+func (s *SecretService) Obj(path dbus.ObjectPath) dbus.BusObject {
 	return s.conn.Object(SecretServiceInterface, path)
 }
 

--- a/secretservice/secretservice_test.go
+++ b/secretservice/secretservice_test.go
@@ -10,7 +10,7 @@ package secretservice
 import (
 	"testing"
 
-	dbus "github.com/keybase/go.dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
The forked one at https://github.com/keybase/go.dbus has issues that make it incompatible with current systems, causing "authentication failed" errors.  This is likely caused by using the user *name* instead of the user id in the `auth.go` in the custom dbus package, which https://github.com/godbus/dbus fixes, likely among other fixes.

- likely point where this was changed/broken in upstream dbus: https://github.com/freedesktop/dbus/blob/bf04d6fb54e54e635be7ae892c01f5a24539e732/NEWS#L965-L972
- keybase/go.dbus uses username: https://github.com/keybase/go.dbus/blob/master/auth.go#L59
- upstream godbus/dbus uses user id: https://github.com/godbus/dbus/blob/master/auth.go#L56-L57

With the switch the connection to DBus works again on several Linux-based systems with various DBus versions running.

To see the exact error, you can run https://github.com/keybase/go.dbus/blob/master/_examples/list-names.go which does not work anymore on modern Linux systems.

```
$ GO111MODULE=off go run _examples/list-names.go
Failed to connect to session bus: dbus: authentication failed
exit status 1
```

(`GO111MODULE` is necessary because go.dbus does not have a go.mod file.)

In contrast, https://github.com/godbus/dbus/blob/master/_examples/list-names.go works:

```
$ go run _examples/list-names.go
Currently owned names on the session bus:
org.freedesktop.DBus
:1.7
org.freedesktop.Notifications
org.keepassxc.KeePassXC.MainWindow
:1.8
org.papill0n.Healthy
<more output here>
```