### PR TITLE
Fix reference to non-existent `keychain.ErrorNotFound`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ accounts, err := keychain.GetGenericPasswordAccounts("MyService")
 // Should have 1 account == "gabriel"
 
 err := keychain.DeleteGenericPasswordItem("MyService", "gabriel")
-if err == keychain.ErrorNotFound {
+if err == keychain.ErrorItemNotFound {
   // Not found
 }
 ```


### PR DESCRIPTION
Just fixing a reference in the readme to an error var that is no longer existent. Thanks for this library!