### PR TITLE
Add errSecUserCanceled error

### DIFF
--- a/keychain.go
+++ b/keychain.go
@@ -65,6 +65,8 @@ var (
 	ErrorDataNotModifiable = Error(C.errSecDataNotModifiable)
 	// ErrorInvalidOwnerEdit corresponds to errSecInvalidOwnerEdit result code
 	ErrorInvalidOwnerEdit = Error(C.errSecInvalidOwnerEdit)
+	// ErrorUserCanceled corresponds to errSecUserCanceled result code
+	ErrorUserCanceled = Error(C.errSecUserCanceled)
 )
 
 func checkError(errCode C.OSStatus) error {
@@ -120,6 +122,8 @@ func (k Error) Error() (msg string) {
 		msg = "The data is not modifiable."
 	case ErrorInvalidOwnerEdit:
 		msg = "An invalid attempt to change the owner of an item."
+	case ErrorUserCanceled:
+		msg = "User canceled the operation."
 	default:
 		msg = "Keychain Error."
 	}


### PR DESCRIPTION
Often reading from Keychain triggers a prompt to confirm that I'm happy for this executable to access this Keychain item. If I dismiss this prompt by hitting escape, we get an error code of -128.

Looking at [SecBase.h](https://opensource.apple.com/source/Security/Security-57740.51.3/base/SecBase.h.auto.html), it looks like this is `errSecUserCanceled`, which makes sense.

This PR adds support for this error code, including a human-readable message taken from SecBase.h.