### PR TITLE
WIP: Support Access Control Flags

### DIFF
--- a/keychain.go
+++ b/keychain.go
@@ -217,6 +217,18 @@ const (
 	AccessibleAccessibleAlwaysThisDeviceOnly = 7
 )
 
+const (
+	AccessControlFlagsUserPresence = 1
+	AccessControlFlagsBiometryAny             = 2
+	AccessControlFlagsBiometryCurrentSet      = 8
+	AccessControlFlagsDevicePasscode          = 16
+	AccessControlFlagsWatch                   = 32
+	AccessControlFlagsOr                      = 16384
+	AccessControlFlagsAnd                     = 32768
+	AccessControlFlagsPrivateKeyUsage         = 1073741824
+	AccessControlFlagsApplicationPassword     = 2147483648
+)
+
 // MatchLimit is whether to limit results on query
 type MatchLimit int
 

--- a/keychain.go
+++ b/keychain.go
@@ -163,6 +163,8 @@ var (
 	AccountKey = attrKey(C.CFTypeRef(C.kSecAttrAccount))
 	// AccessGroupKey is for kSecAttrAccessGroup
 	AccessGroupKey = attrKey(C.CFTypeRef(C.kSecAttrAccessGroup))
+	// AccessControlKey is for kSecAttrAccessControl
+	AccessControlKey = attrKey(C.CFTypeRef(C.kSecAttrAccessControl))
 	// DataKey is for kSecValueData
 	DataKey = attrKey(C.CFTypeRef(C.kSecValueData))
 	// DescriptionKey is for kSecAttrDescription
@@ -217,16 +219,18 @@ const (
 	AccessibleAccessibleAlwaysThisDeviceOnly = 7
 )
 
-const (
-	AccessControlFlagsUserPresence = 1
-	AccessControlFlagsBiometryAny             = 2
-	AccessControlFlagsBiometryCurrentSet      = 8
-	AccessControlFlagsDevicePasscode          = 16
-	AccessControlFlagsWatch                   = 32
-	AccessControlFlagsOr                      = 16384
-	AccessControlFlagsAnd                     = 32768
-	AccessControlFlagsPrivateKeyUsage         = 1073741824
-	AccessControlFlagsApplicationPassword     = 2147483648
+type AccessControlFlags C.SecAccessControlCreateFlags
+
+var (
+	AccessControlFlagsUserPresence        C.SecAccessControlCreateFlags = 1
+	AccessControlFlagsBiometryAny                                       = 2
+	AccessControlFlagsBiometryCurrentSet                                = 8
+	AccessControlFlagsDevicePasscode                                    = 16
+	AccessControlFlagsWatch                                             = 32
+	AccessControlFlagsOr                                                = 16384
+	AccessControlFlagsAnd                                               = 32768
+	AccessControlFlagsPrivateKeyUsage                                   = 1073741824
+	AccessControlFlagsApplicationPassword                               = 2147483648
 )
 
 // MatchLimit is whether to limit results on query
@@ -309,6 +313,18 @@ func (k *Item) SetData(b []byte) {
 // SetAccessGroup sets the access group attribute
 func (k *Item) SetAccessGroup(ag string) {
 	k.SetString(AccessGroupKey, ag)
+}
+
+func (k *Item) SetAccessControlFlags(accessibility Accessible, flags C.CFOptionFlags) error {
+	cfAccessibility := accessibleTypeRef[accessibility]
+	var err *C.CFErrorRef
+	var allocator C.CFAllocatorRef = 0 // null
+	ac := C.SecAccessControlCreateWithFlags(allocator, cfAccessibility, flags, err)
+	if err != nil {
+		return fmt.Errorf("failed to create access control: %+v", err)
+	}
+	k.attr[AccessControlKey] = ac
+	return nil
 }
 
 // SetSynchronizable sets the synchronizable attribute


### PR DESCRIPTION
This is a rough draft to enable access control flags.

I am not very familiar with the Keychain API, nor Swift/Go integration, so this implementation is likely flawed.

1. I am not sure how to easily or safely test this change, especially given that by its nature it cannot be run non-interactively.
2. I could not figure out how to reference the flag values (like `SecAccessControlCreateFlags.userPresence` so I re-created the values instead.
3. I am not sure if using the native type (`SecAccessControlCreateFlags` which seems to boil down to a `ulong`) in Go. Is a conversion layer better than direct referencing like I am doing?

Most of what I am doing here is guessing... wonder if any insight can be given on further changes that should be made, or if a more experienced contributor could help me get this over the finish line.