### PR TITLE
Remove deprecated function call

### DIFF
--- a/macos.go
+++ b/macos.go
@@ -23,9 +23,3 @@ var accessibleTypeRef = map[Accessible]C.CFTypeRef{
 	// Only available in 10.10
 	//AccessibleWhenPasscodeSetThisDeviceOnly:  C.CFTypeRef(C.kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly),
 }
-
-// DeleteItemRef deletes a keychain item reference.
-func DeleteItemRef(ref C.CFTypeRef) error {
-	errCode := C.SecKeychainItemDelete(C.SecKeychainItemRef(ref))
-	return checkError(errCode)
-}

--- a/macos_test.go
+++ b/macos_test.go
@@ -68,7 +68,7 @@ func TestGenericPasswordRef(t *testing.T) {
 	} else if ref == 0 {
 		t.Fatal("Missing result")
 	} else {
-		err = DeleteItemRef(ref)
+		err = DeleteItem(item)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
As suggested in https://github.com/keybase/go-keychain/issues/88 PR https://github.com/keybase/go-keychain/pull/77 inadvertently re-introduced a deprecated call. This PR removes that call but preserves all the other functionality that was intentionally re-introduced.

```
# github.com/keybase/go-keychain
cgo-gcc-prolog:53:11: warning: 'SecKeychainItemDelete' is deprecated: first deprecated in macOS 10.10 - SecKeychain is deprecated [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Security.framework/Headers/SecKeychainItem.h:257:10: note: 'SecKeychainItemDelete' has been explicitly marked deprecated here
```