### PR TITLE
WIP: Added support for biometrics (Touch ID/Face ID)

### DIFF
--- a/corefoundation.go
+++ b/corefoundation.go
@@ -7,6 +7,7 @@ package keychain
 #cgo LDFLAGS: -framework CoreFoundation
 
 #include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
 
 // Can't cast a *uintptr to *unsafe.Pointer in Go, and casting
 // C.CFTypeRef to unsafe.Pointer is unsafe in Go, so have shim functions to
@@ -185,6 +186,12 @@ func ConvertMapToCFDictionary(attr map[string]interface{}) (C.CFDictionaryRef, e
 		switch val := i.(type) {
 		default:
 			return 0, fmt.Errorf("Unsupported value type: %v", reflect.TypeOf(i))
+		case *AuthenticationContext:
+			// Ignore this, the pointer can't be added to the dictionary
+			// This value is used within the QueryItemRef functions
+			continue
+		case C.SecAccessControlRef:
+			valueRef = C.CFTypeRef(val)
 		case C.CFTypeRef:
 			valueRef = val
 		case bool:


### PR DESCRIPTION
First draft at [tested and working](https://github.com/99designs/aws-vault/issues/273#issuecomment-2095694384) TouchID support.

Still need to write unit tests and add some more config options for SetAccessControl (i.e `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`) is currently hard coded. Ideally this should just reference the value from SetAccessible (if any).

Also getting the following error which is hard to fix right now. Any ideas would be great.

```
./keychain.go:28:69: note: passing argument to parameter 'context' here
cgo-gcc-prolog:53:41: warning: incompatible pointer types passing 'struct LAContext *' to parameter of type 'LAContext *' [-Wincompatible-pointer-types]
```

Currently the only way to use this is within a MacOS app (with developer ID, code sign etc). It's beyond the scope of this project as it would more so be the consumers of this project that would be using it. Once I add a PR for [aws-vault](https://github.com/99designs/aws-vault) I will come back and link to those instructions.